### PR TITLE
Remove underscore from MotionPlanResponse members

### DIFF
--- a/src/stomp_moveit_planning_context.cpp
+++ b/src/stomp_moveit_planning_context.cpp
@@ -86,9 +86,9 @@ bool StompPlanningContext::solve(planning_interface::MotionPlanResponse& res)
   auto time_start = std::chrono::steady_clock::now();
 
   // Response output
-  auto& trajectory = res.trajectory_;
-  auto& planning_time = res.planning_time_;
-  auto& result_code = res.error_code_.val;
+  auto& trajectory = res.trajectory;
+  auto& planning_time = res.planning_time;
+  auto& result_code = res.error_code.val;
   result_code = moveit_msgs::msg::MoveItErrorCodes::SUCCESS;  // Default to happy path
 
   // Extract start and goal states


### PR DESCRIPTION
Address compiler errors caused by merging https://github.com/ros-planning/moveit2/commit/8bfe782d6254997d185644fa3eb358d2b79d69b2