### PR TITLE
Remove STOMP workspace dependencies

### DIFF
--- a/stomp_moveit.repos
+++ b/stomp_moveit.repos
@@ -1,12 +1,4 @@
 repositories:
-  stomp:
-    type: git
-    url: https://github.com/ros-industrial/stomp
-    version: main
-  ros_industrial_cmake_boilerplate:
-    type: git
-    url: https://github.com/ros-industrial/ros_industrial_cmake_boilerplate
-    version: master
   moveit_visual_tools:
     type: git
     url: https://github.com/ros-planning/moveit_visual_tools


### PR DESCRIPTION
The stomp and boilerplate packages have been released, we should be able to go without them.

(of course we can remove MVT as well, I will do so in a separate step while removing the MVT dependency requirement in preparation of migrating this to the moveit2 repo)