### PR TITLE
Penalty-based path constraints

### DIFF
--- a/include/stomp_moveit/cost_functions.hpp
+++ b/include/stomp_moveit/cost_functions.hpp
@@ -1,84 +1,79 @@
 #pragma once
 
 #include <Eigen/Geometry>
+
 #include <moveit/planning_scene/planning_scene.h>
+#include <moveit/kinematic_constraints/kinematic_constraint.h>
+
 #include <stomp_moveit/stomp_moveit_task.hpp>
 #include <stomp_moveit/conversion_functions.hpp>
 
 namespace stomp_moveit
 {
-namespace costs
+namespace
 {
-// Interpolation step size for collision checking (joint space, L2 norm)
-constexpr double COL_CHECK_DISTANCE = 0.05;
-
-CostFn get_collision_cost_function(const std::shared_ptr<const planning_scene::PlanningScene>& planning_scene,
-                                   const moveit::core::JointModelGroup* group, double collision_penalty)
+// Decides if the given state position vector is valid or not - example use cases are collision or constraint checking
+using StateValidatorFn = std::function<bool(const Eigen::VectorXd& state_positions)>;
+CostFn get_cost_function_from_state_validator(const StateValidatorFn state_validator_fn, double interpolation_step_size,
+                                              double penalty)
 {
-  const auto& joints = group ? group->getActiveJointModels() : planning_scene->getRobotModel()->getActiveJointModels();
-  const auto& group_name = group ? group->getName() : "";
-
   CostFn cost_fn = [=](const Eigen::MatrixXd& values, Eigen::VectorXd& costs, bool& validity) {
-    static thread_local moveit::core::RobotState sample_state(planning_scene->getCurrentState());
-
     costs.setZero(values.cols());
 
     validity = true;
-    std::vector<std::pair<long, long>> collision_windows;
-    bool in_collision_window = false;
+    std::vector<std::pair<long, long>> invalid_windows;
+    bool in_invalid_window = false;
 
-    // Iterate over sample waypoint pairs and check for collisions in each segment.
-    // If a collision is found, weighted penalty costs are applied to both waypoints.
-    // Subsequent collisions are assumed to have the same cause (same object), so
-    // we are keeping track of 'collision_windows' which are used for smoothing out
-    // the costs per assumed 'object' with a gaussian, penalizing neighboring but
-    // collision-free states as well.
+    // Iterate over sample waypoint pairs and check for validity in each segment.
+    // If an invalid state is found, weighted penalty costs are applied to both waypoints.
+    // Subsequent invalid states are assumed to have the same cause, so we are keeping track
+    // of "invalid windows" which are used for smoothing out the costs per violation cause
+    // with a gaussian, penalizing neighboring valid states as well.
     for (int timestep = 0; timestep < values.cols() - 1; ++timestep)
     {
       Eigen::VectorXd current = values.col(timestep);
       Eigen::VectorXd next = values.col(timestep + 1);
       const double segment_distance = (next - current).norm();
       double interpolation_fraction = 0.0;
-      const double interpolation_step = std::min(0.5, COL_CHECK_DISTANCE / segment_distance);
-      bool found_collision = false;
-      while (!found_collision && interpolation_fraction < 1.0)
+      const double interpolation_step = std::min(0.5, interpolation_step_size / segment_distance);
+      bool found_invalid_state = false;
+      while (!found_invalid_state && interpolation_fraction < 1.0)
       {
         Eigen::VectorXd sample_vec = (1 - interpolation_fraction) * current + interpolation_fraction * next;
-        set_joint_positions(sample_vec, joints, sample_state);
-        sample_state.update();
-        found_collision = planning_scene->isStateColliding(sample_state, group_name);
+
+        found_invalid_state = !state_validator_fn(sample_vec);
         interpolation_fraction += interpolation_step;
       }
 
-      if (found_collision)
+      if (found_invalid_state)
       {
-        // Apply weighted collision penalties -> This trajectory is definitely invalid
-        costs(timestep) = (1 - interpolation_fraction) * collision_penalty;
-        costs(timestep + 1) = interpolation_fraction * collision_penalty;
+        // Apply weighted penalties -> This trajectory is definitely invalid
+        costs(timestep) = (1 - interpolation_fraction) * penalty;
+        costs(timestep + 1) = interpolation_fraction * penalty;
         validity = false;
 
-        // Open new collision window when this is the first detected collision in a group
-        if (!in_collision_window)
+        // Open new invalid window when this is the first detected invalid state in a group
+        if (!in_invalid_window)
         {
-          collision_windows.emplace_back(timestep, values.cols());
-          in_collision_window = true;
+          invalid_windows.emplace_back(timestep, values.cols());
+          in_invalid_window = true;
         }
       }
       else
       {
-        // Close current collision window if the current state is collision-free
-        if (in_collision_window)
+        // Close current invalid window if the current state is valid
+        if (in_invalid_window)
         {
-          collision_windows.back().second = timestep - 1;
-          in_collision_window = false;
+          invalid_windows.back().second = timestep - 1;
+          in_invalid_window = false;
         }
       }
     }
 
-    // Smooth out cost of colliding segments using a gaussian
+    // Smooth out cost of invalid segments using a gaussian
     // The standard deviation is picked so that neighboring states
-    // before and after the collision are penalized as well.
-    for (const auto& [start, end] : collision_windows)
+    // before and after the violation are penalized as well.
+    for (const auto& [start, end] : invalid_windows)
     {
       const double window_size = static_cast<double>(end - start) + 1;
       const double sigma = window_size / 5.0;
@@ -95,6 +90,77 @@ CostFn get_collision_cost_function(const std::shared_ptr<const planning_scene::P
   };
 
   return cost_fn;
+}
+}  // namespace
+namespace costs
+{
+// Interpolation step size for collision checking (joint space, L2 norm)
+constexpr double COL_CHECK_DISTANCE = 0.05;
+constexpr double CONSTRAINT_CHECK_DISTANCE = 0.1;
+
+CostFn get_collision_cost_function(const std::shared_ptr<const planning_scene::PlanningScene>& planning_scene,
+                                   const moveit::core::JointModelGroup* group, double collision_penalty)
+{
+  const auto& joints = group ? group->getActiveJointModels() : planning_scene->getRobotModel()->getActiveJointModels();
+  const auto& group_name = group ? group->getName() : "";
+
+  StateValidatorFn collision_validator_fn = [=](const Eigen::VectorXd& positions) {
+    static moveit::core::RobotState state(planning_scene->getCurrentState());
+
+    // Update robot state values
+    set_joint_positions(positions, joints, state);
+    state.update();
+
+    return !planning_scene->isStateColliding(state, group_name);
+  };
+
+  return get_cost_function_from_state_validator(collision_validator_fn, COL_CHECK_DISTANCE, collision_penalty);
+}
+
+CostFn get_constraints_cost_function(const std::shared_ptr<const planning_scene::PlanningScene>& planning_scene,
+                                     const moveit::core::JointModelGroup* group,
+                                     const moveit_msgs::msg::Constraints& constraints_msg, double constraints_penalty)
+{
+  const auto& joints = group ? group->getActiveJointModels() : planning_scene->getRobotModel()->getActiveJointModels();
+  const auto& group_name = group ? group->getName() : "";
+
+  kinematic_constraints::KinematicConstraintSet constraints_set(planning_scene->getRobotModel());
+  constraints_set.add(constraints_msg, planning_scene->getTransforms());
+
+  StateValidatorFn constraints_validator_fn = [=, constraints =
+                                                      std::move(constraints_set)](const Eigen::VectorXd& positions) {
+    static moveit::core::RobotState state(planning_scene->getCurrentState());
+
+    // Update robot state values
+    set_joint_positions(positions, joints, state);
+    state.update();
+
+    // NOTE: the returned ConstraintEvaluationResult also provides a `double distance` which might be used as an
+    // actual cost gradient instead of the binary state penalty
+    return constraints.decide(state).satisfied;
+  };
+
+  return get_cost_function_from_state_validator(constraints_validator_fn, CONSTRAINT_CHECK_DISTANCE,
+                                                constraints_penalty);
+}
+CostFn sum(const std::vector<CostFn>& cost_functions)
+{
+  return [=](const Eigen::MatrixXd& values, Eigen::VectorXd& overall_costs, bool& overall_validity) {
+    overall_validity = true;
+    overall_costs.setZero(values.cols());
+
+    auto costs = overall_costs;
+    for (const auto& cost_fn : cost_functions)
+    {
+      bool valid = true;
+      cost_fn(values, costs, valid);
+
+      // Sum results
+      overall_validity = overall_validity && valid;
+      overall_costs += costs;
+    }
+    return true;
+  };
 }
 }  // namespace costs
 }  // namespace stomp_moveit

--- a/src/stomp_moveit_planner_plugin.cpp
+++ b/src/stomp_moveit_planner_plugin.cpp
@@ -80,18 +80,6 @@ public:
       return false;
     }
 
-    const auto& pc = req.path_constraints;
-    if (!(pc.joint_constraints.empty() && pc.position_constraints.empty() && pc.orientation_constraints.empty() &&
-          pc.visibility_constraints.empty()))
-    {
-      RCLCPP_WARN(LOGGER, "Ignoring path constraints - not implemented!");
-    }
-
-    if (!req.trajectory_constraints.constraints.empty())
-    {
-      RCLCPP_WARN(LOGGER, "Ignoring trajectory constraints - not implemented!");
-    }
-
     if (!req.reference_trajectories.empty())
     {
       RCLCPP_WARN(LOGGER, "Ignoring reference trajectories - not implemented!");

--- a/src/stomp_moveit_planning_context.cpp
+++ b/src/stomp_moveit_planning_context.cpp
@@ -95,24 +95,41 @@ bool extractSeedTrajectory(const planning_interface::MotionPlanRequest& req,
 stomp::TaskPtr createStompTask(const stomp::StompConfiguration& config, StompPlanningContext& context)
 {
   const size_t num_timesteps = config.num_timesteps;
-  const double collision_penalty = 1.0;
-  const auto& planning_scene = context.getPlanningScene();
+  const auto planning_scene = context.getPlanningScene();
   const auto group = planning_scene->getRobotModel()->getJointModelGroup(context.getGroupName());
-  const std::vector<double> stddev(group->getActiveJointModels().size(), 0.1);
 
-  // Create STOMP planning task
-  // Noise, cost, and filter functions are provided for planning.
-  // The iteration and done callbacks are used for path and trajectory visualization.
+  // Check if we do have path constraints
+  const auto& req = context.getMotionPlanRequest();
+  kinematic_constraints::KinematicConstraintSet constraints(planning_scene->getRobotModel());
+  constraints.add(req.path_constraints, planning_scene->getTransforms());
+
+  // Create callback functions for STOMP task
+  // Cost, noise and filter functions are provided for planning.
+  // TODO(henningkayser): parameterize cost penalties
   using namespace stomp_moveit;
+  CostFn cost_fn;
+  if (!constraints.empty())
+  {
+    cost_fn = costs::sum({ costs::get_collision_cost_function(planning_scene, group, 1.0 /* collision penalty */),
+                           costs::get_constraints_cost_function(planning_scene, group, constraints.getAllConstraints(),
+                                                                1.0 /* constraint penalty */) });
+  }
+  else
+  {
+    cost_fn = costs::get_collision_cost_function(planning_scene, group, 1.0 /* collision penalty */);
+  }
+
+  // TODO(henningkayser): parameterize stddev
+  const std::vector<double> stddev(group->getActiveJointModels().size(), 0.1);
   auto noise_generator_fn = noise::get_normal_distribution_generator(num_timesteps, stddev);
-  auto cost_fn = costs::get_collision_cost_function(planning_scene, group, collision_penalty);
   auto filter_fn =
       filters::chain({ filters::simple_smoothing_matrix(num_timesteps), filters::enforce_position_bounds(group) });
-
   auto iteration_callback_fn =
       visualization::get_iteration_path_publisher(context.getPathPublisher(), planning_scene, group);
   auto done_callback_fn =
       visualization::get_success_trajectory_publisher(context.getPathPublisher(), planning_scene, group);
+
+  // Initialize and return STOMP task
   stomp::TaskPtr task =
       std::make_shared<ComposableTask>(noise_generator_fn, cost_fn, filter_fn, iteration_callback_fn, done_callback_fn);
   return task;


### PR DESCRIPTION
This adds a penalty-based cost function for path constraints that works just the same as the collision cost function. Binary checks are used for assigning a constant penalty cost to waypoints which is in turn smoothed out using a gaussian. The example includes a proof of concept (keeping the end-effector orientation steady), I still need to add plugin support for this. Of course, this is rather experimental, and using dynamic costs (e.g. orientation distance) would be much more efficient than this. However, this is a version that should work for all supported constraints and we can optimize the cost functions later.