### PR TITLE
more fixes for #8

### DIFF
--- a/src/stomp_moveit_planning_context.cpp
+++ b/src/stomp_moveit_planning_context.cpp
@@ -174,11 +174,11 @@ bool StompPlanningContext::solve(planning_interface::MotionPlanResponse& res)
 
   std::condition_variable cv;
   std::mutex cv_mutex;
-  bool finished;
+  bool finished = false;
   auto timeout_future = std::async(std::launch::async, [&, stomp = stomp_]() {
     std::unique_lock<std::mutex> lock(cv_mutex);
     cv.wait_for(lock, std::chrono::duration<double>(req.allowed_planning_time), [&finished] { return finished; });
-    if (stomp && !finished)
+    if (!finished)
     {
       stomp->cancel();
     }


### PR DESCRIPTION
finished happened to be uninitialized + `stomp` will always have a value