### PR TITLE
Implement joint limit filter

### DIFF
--- a/include/stomp_moveit/filter_functions.hpp
+++ b/include/stomp_moveit/filter_functions.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <Eigen/Geometry>
+#include <moveit/robot_model/joint_model_group.h>
 #include <stomp_moveit/stomp_moveit_task.hpp>
 
 #include <stomp/utils.h>
@@ -19,6 +20,33 @@ FilterFn simple_smoothing_matrix(size_t num_timesteps)
     for (int i = 0; i < filtered_values.rows(); ++i)
     {
       filtered_values.row(i).transpose() = smoothing_matrix * (filtered_values.row(i).transpose());
+    }
+    return true;
+  };
+}
+FilterFn enforce_position_bounds(const moveit::core::JointModelGroup* group)
+{
+  return [=](const Eigen::MatrixXd& values, Eigen::MatrixXd& filtered_values) {
+    filtered_values = values;
+    const auto& joints = group->getActiveJointModels();
+    for (size_t i = 0; i < joints.size(); ++i)
+    {
+      for (int j = 0; j < filtered_values.cols(); ++j)
+      {
+        joints.at(i)->enforcePositionBounds(&filtered_values.coeffRef(i, j));
+      }
+    }
+    return true;
+  };
+}
+FilterFn chain(const std::vector<FilterFn>& filter_functions)
+{
+  return [=](const Eigen::MatrixXd& values, Eigen::MatrixXd& filtered_values) {
+    Eigen::MatrixXd values_in = values;
+    for (const auto& filter_fn : filter_functions)
+    {
+      filter_fn(values_in, filtered_values);
+      values_in = filtered_values;
     }
     return true;
   };

--- a/include/stomp_moveit/filter_functions.hpp
+++ b/include/stomp_moveit/filter_functions.hpp
@@ -10,8 +10,15 @@ namespace stomp_moveit
 {
 namespace filters
 {
+// \brief An empty placeholder filter that doesn't apply any updates to the trajectory.
 const static FilterFn NoFilter = [](const Eigen::MatrixXd& values, Eigen::MatrixXd& filtered_values) { return true; };
 
+/**
+ * Creates a filter function that applies Stomp's smoothing matrix for the whole trajectory.
+ *
+ * @param num_timesteps The number of trajectory waypoints configured for STOMP
+ * @return The smoothing filter function to be used for the STOMP task
+ */
 FilterFn simple_smoothing_matrix(size_t num_timesteps)
 {
   Eigen::MatrixXd smoothing_matrix;
@@ -24,6 +31,13 @@ FilterFn simple_smoothing_matrix(size_t num_timesteps)
     return true;
   };
 }
+
+/**
+ * Creates a filter function that clips all waypoint positions using the joint bounds of a given JointModelGroup.
+ *
+ * @param group The JointModelGroup providing the joint limits
+ * @return The filter function for enforcing joint limits
+ */
 FilterFn enforce_position_bounds(const moveit::core::JointModelGroup* group)
 {
   return [=](const Eigen::MatrixXd& values, Eigen::MatrixXd& filtered_values) {
@@ -39,6 +53,13 @@ FilterFn enforce_position_bounds(const moveit::core::JointModelGroup* group)
     return true;
   };
 }
+
+/**
+ * Helper function for applying multiple trajectory update filters in sequential order.
+ *
+ * @param filter_functions The ordered vector of filter functions to apply
+ * @return The filter function applying all the configured filters in sequence
+ */
 FilterFn chain(const std::vector<FilterFn>& filter_functions)
 {
   return [=](const Eigen::MatrixXd& values, Eigen::MatrixXd& filtered_values) {

--- a/src/stomp_moveit_example.cpp
+++ b/src/stomp_moveit_example.cpp
@@ -86,7 +86,8 @@ int main(int argc, char** argv)
   auto noise_generator_fn = noise::get_normal_distribution_generator(config.num_timesteps, { 0.1, 0.1, 0.1, 0.1, 0.05,
                                                                                              0.05, 0.05 } /* stddev */);
   auto cost_fn = costs::get_collision_cost_function(planning_scene, group, 1.0 /* collision penalty */);
-  auto filter_fn = filters::simple_smoothing_matrix(config.num_timesteps);
+  auto filter_fn = filters::chain(
+      { filters::simple_smoothing_matrix(config.num_timesteps), filters::enforce_position_bounds(group) });
   auto iteration_callback_fn = visualization::get_iteration_path_publisher(visual_tools, group);
   auto done_callback_fn = visualization::get_success_trajectory_publisher(visual_tools, group);
   stomp::TaskPtr task =

--- a/src/stomp_moveit_planning_context.cpp
+++ b/src/stomp_moveit_planning_context.cpp
@@ -106,7 +106,8 @@ stomp::TaskPtr createStompTask(const stomp::StompConfiguration& config, const St
   using namespace stomp_moveit;
   auto noise_generator_fn = noise::get_normal_distribution_generator(num_timesteps, stddev);
   auto cost_fn = costs::get_collision_cost_function(planning_scene, group, collision_penalty);
-  auto filter_fn = filters::simple_smoothing_matrix(num_timesteps);
+  auto filter_fn =
+      filters::chain({ filters::simple_smoothing_matrix(num_timesteps), filters::enforce_position_bounds(group) });
   // TODO: enable support for visualization
   // auto iteration_callback_fn = visualization::get_iteration_path_publisher(visual_tools, group);
   // auto done_callback_fn = visualization::get_success_trajectory_publisher(visual_tools, group);


### PR DESCRIPTION
This implements a simple filter function for keeping the noisy joint positions within bounds. This function is basically an adaption of the old implementation here https://github.com/ros-industrial/stomp_ros/blob/melodic-devel/stomp_moveit/src/noisy_filters/joint_limits.cpp.

Side note: The old joint limits filter had start and goal state locking implemented which hasn't been added here. I find that it's a bit out of place for a joint limits check, but we are also not applying noise on start and goal states, so they will never be modified with the existing noise generator. IMO, this is fine, it's already hard enough to optimize the trajectory for a given pair of states. Allowing for optimizing the end points makes it supposedly very difficult to get reliable results. It would be more appropriate to use something like pick_ik to get good start and end points first, and then call STOMP on those