### PR TITLE
Replace visual_tools to publish planned trajectory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ moveit_package()
 find_package(ament_cmake REQUIRED)
 find_package(stomp REQUIRED)
 find_package(moveit_core REQUIRED)
-find_package(moveit_ros REQUIRED)
+find_package(moveit_ros_planning REQUIRED)
 find_package(moveit_visual_tools REQUIRED)
 find_package(generate_parameter_library REQUIRED)
 
@@ -27,6 +27,7 @@ add_library(stomp_moveit_plugin SHARED
 )
 ament_target_dependencies(stomp_moveit_plugin
   moveit_core
+  moveit_ros_planning
 )
 target_link_libraries(stomp_moveit_plugin stomp::stomp stomp_moveit_parameters)
 
@@ -44,7 +45,7 @@ install(TARGETS stomp_moveit_plugin stomp_moveit_parameters
 add_executable(stomp_moveit_example src/stomp_moveit_example.cpp)
 ament_target_dependencies(stomp_moveit_example
   moveit_core
-  moveit_ros
+  moveit_ros_planning
   moveit_visual_tools
 )
 target_link_libraries(stomp_moveit_example stomp::stomp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,11 +7,13 @@ moveit_package()
 
 # find dependencies
 find_package(ament_cmake REQUIRED)
-find_package(stomp REQUIRED)
-find_package(moveit_core REQUIRED)
-find_package(moveit_ros_planning REQUIRED)
-find_package(moveit_visual_tools REQUIRED)
 find_package(generate_parameter_library REQUIRED)
+find_package(moveit_core REQUIRED)
+find_package(moveit_visual_tools REQUIRED)
+find_package(std_msgs REQUIRED)
+find_package(stomp REQUIRED)
+find_package(visualization_msgs REQUIRED)
+find_package(tf2_eigen REQUIRED)
 
 generate_parameter_library(stomp_moveit_parameters res/stomp_moveit.yaml)
 
@@ -27,7 +29,9 @@ add_library(stomp_moveit_plugin SHARED
 )
 ament_target_dependencies(stomp_moveit_plugin
   moveit_core
-  moveit_ros_planning
+  std_msgs
+  tf2_eigen
+  visualization_msgs
 )
 target_link_libraries(stomp_moveit_plugin stomp::stomp stomp_moveit_parameters)
 
@@ -45,8 +49,10 @@ install(TARGETS stomp_moveit_plugin stomp_moveit_parameters
 add_executable(stomp_moveit_example src/stomp_moveit_example.cpp)
 ament_target_dependencies(stomp_moveit_example
   moveit_core
-  moveit_ros_planning
   moveit_visual_tools
+  std_msgs
+  tf2_eigen
+  visualization_msgs
 )
 target_link_libraries(stomp_moveit_example stomp::stomp)
 

--- a/include/stomp_moveit/stomp_moveit_planning_context.hpp
+++ b/include/stomp_moveit/stomp_moveit_planning_context.hpp
@@ -25,8 +25,12 @@ public:
 
   void clear() override;
 
+  void setPathPublisher(std::shared_ptr<rclcpp::Publisher<visualization_msgs::msg::MarkerArray>> path_publisher);
+  std::shared_ptr<rclcpp::Publisher<visualization_msgs::msg::MarkerArray>> getPathPublisher();
+
 private:
   const stomp_moveit::Params params_;
   std::shared_ptr<stomp::Stomp> stomp_;
+  std::shared_ptr<rclcpp::Publisher<visualization_msgs::msg::MarkerArray>> path_publisher_;
 };
 }  // namespace stomp_moveit

--- a/include/stomp_moveit/trajectory_visualization.hpp
+++ b/include/stomp_moveit/trajectory_visualization.hpp
@@ -30,9 +30,9 @@ const auto GREEN = []() {
 const auto TRANSLUCENT_LIGHT = []() {
   std_msgs::msg::ColorRGBA color;
   color.r = 0.1;
-  color.g = 0.1;
+  color.g = 0.8;
   color.b = 0.1;
-  color.a = 0.1;
+  color.a = 0.5;
   return color;
 }();
 }  // namespace
@@ -44,13 +44,11 @@ bool publishTrajectoryPoints(const robot_trajectory::RobotTrajectory& robot_traj
 {
   // Create Sphere Marker
   visualization_msgs::msg::Marker sphere_marker;
-  sphere_marker.header.frame_id = "world";
-  sphere_marker.ns = "stomp";
+  sphere_marker.header.frame_id = "panda_link0";
+  sphere_marker.ns = "Path";
   sphere_marker.type = visualization_msgs::msg::Marker::SPHERE;
   sphere_marker.action = visualization_msgs::msg::Marker::ADD;
   sphere_marker.lifetime = rclcpp::Duration(0, 0);  // Infinite lifetime
-  sphere_marker.points.resize(1);
-  sphere_marker.colors.resize(1);
   sphere_marker.scale.x = 0.01;
   sphere_marker.scale.y = 0.01;
   sphere_marker.scale.z = 0.01;
@@ -87,8 +85,7 @@ bool publishTrajectoryPoints(const robot_trajectory::RobotTrajectory& robot_traj
 
     // Create a sphere point
     // Add the point pair to the line message
-    sphere_marker.points.resize(1);
-    sphere_marker.colors.back() = color;
+    sphere_marker.color = color;
 
     sphere_marker.id = index;
 
@@ -100,8 +97,6 @@ bool publishTrajectoryPoints(const robot_trajectory::RobotTrajectory& robot_traj
     return false;
   }
 
-  //RCLCPP_ERROR_STREAM(LOGGER, "get_subscription_count: " << marker_publisher->get_subscription_count()
-  //                                                       << " # of markers: " << markers_array.markers.size());
   marker_publisher->publish(markers_array);
   return true;
 }

--- a/include/stomp_moveit/trajectory_visualization.hpp
+++ b/include/stomp_moveit/trajectory_visualization.hpp
@@ -75,8 +75,8 @@ get_iteration_path_publisher(rclcpp::Publisher<visualization_msgs::msg::MarkerAr
 
   auto path_publisher = [marker_publisher, group, reference_state = moveit::core::RobotState(scene->getCurrentState())](
                             int /*iteration_number*/, double /*cost*/, const Eigen::MatrixXd& values) {
-    static thread_local robot_trajectory::RobotTrajectory trajectory(planning_scene_monitor->getRobotModel(), group);
-    fill_robot_trajectory(values, *reference_state, trajectory);
+    static thread_local robot_trajectory::RobotTrajectory trajectory(reference_state.getRobotModel(), group);
+    fill_robot_trajectory(values, reference_state, trajectory);
 
     const moveit::core::LinkModel* ee_parent_link = group->getOnlyOneEndEffectorTip();
 
@@ -101,10 +101,10 @@ get_success_trajectory_publisher(rclcpp::Publisher<visualization_msgs::msg::Mark
   auto path_publisher = [marker_publisher, group, reference_state = moveit::core::RobotState(scene->getCurrentState())](
                             bool success, int /*total_iterations*/, double /*final_cost*/,
                             const Eigen::MatrixXd& values) {
-    static thread_local robot_trajectory::RobotTrajectory trajectory(reference_state->getRobotModel(), group);
+    static thread_local robot_trajectory::RobotTrajectory trajectory(reference_state.getRobotModel(), group);
     if (success)
     {
-      fill_robot_trajectory(values, *reference_state, trajectory);
+      fill_robot_trajectory(values, reference_state, trajectory);
 
       const moveit::core::LinkModel* ee_parent_link = group->getOnlyOneEndEffectorTip();
 

--- a/include/stomp_moveit/trajectory_visualization.hpp
+++ b/include/stomp_moveit/trajectory_visualization.hpp
@@ -5,55 +5,171 @@
 #include <stomp_moveit/stomp_moveit_task.hpp>
 #include <stomp_moveit/conversion_functions.hpp>
 
+#include <std_msgs/msg/color_rgba.hpp>
+#include <tf2_eigen/tf2_eigen.hpp>
+#include <visualization_msgs/msg/marker.hpp>
+#include <visualization_msgs/msg/marker_array.hpp>
+
 namespace stomp_moveit
 {
 namespace visualization
 {
+
+namespace
+{
+const rclcpp::Logger LOGGER = rclcpp::get_logger("stomp_moveit");
+const auto GREEN = []() {
+  std_msgs::msg::ColorRGBA color;
+  color.r = 0.1;
+  color.g = 0.8;
+  color.b = 0.1;
+  color.a = 1.0;
+  return color;
+}();
+
+const auto TRANSLUCENT_LIGHT = []() {
+  std_msgs::msg::ColorRGBA color;
+  color.r = 0.1;
+  color.g = 0.1;
+  color.b = 0.1;
+  color.a = 0.1;
+  return color;
+}();
+}  // namespace
+
+bool publishTrajectoryPoints(const robot_trajectory::RobotTrajectory& robot_trajectory,
+                             const moveit::core::LinkModel* ee_parent_link,
+                             rclcpp::Publisher<visualization_msgs::msg::MarkerArray>::SharedPtr marker_publisher,
+                             const std_msgs::msg::ColorRGBA& color = GREEN)
+{
+  // Create Sphere Marker
+  visualization_msgs::msg::Marker sphere_marker;
+  sphere_marker.header.frame_id = "world";
+  sphere_marker.ns = "stomp";
+  sphere_marker.type = visualization_msgs::msg::Marker::SPHERE;
+  sphere_marker.action = visualization_msgs::msg::Marker::ADD;
+  sphere_marker.lifetime = rclcpp::Duration(0, 0);  // Infinite lifetime
+  sphere_marker.points.resize(1);
+  sphere_marker.colors.resize(1);
+  sphere_marker.scale.x = 0.01;
+  sphere_marker.scale.y = 0.01;
+  sphere_marker.scale.z = 0.01;
+  sphere_marker.frame_locked = false;
+
+  visualization_msgs::msg::MarkerArray markers_array;
+  // Visualize end effector position of cartesian path
+  for (std::size_t index = 0; index < robot_trajectory.getWayPointCount(); index++)
+  {
+    const Eigen::Isometry3d& tip_pose = robot_trajectory.getWayPoint(index).getGlobalLinkTransform(ee_parent_link);
+    sphere_marker.pose = tf2::toMsg(tip_pose);
+
+    // Normalize pose
+    double norm = 0;
+    norm += sphere_marker.pose.orientation.w * sphere_marker.pose.orientation.w;
+    norm += sphere_marker.pose.orientation.x * sphere_marker.pose.orientation.x;
+    norm += sphere_marker.pose.orientation.y * sphere_marker.pose.orientation.y;
+    norm += sphere_marker.pose.orientation.z * sphere_marker.pose.orientation.z;
+    norm = std::sqrt(norm);
+    if (norm < std::numeric_limits<double>::epsilon())
+    {
+      sphere_marker.pose.orientation.w = 1;
+      sphere_marker.pose.orientation.x = 0;
+      sphere_marker.pose.orientation.y = 0;
+      sphere_marker.pose.orientation.z = 0;
+    }
+    else
+    {
+      sphere_marker.pose.orientation.w = sphere_marker.pose.orientation.w / norm;
+      sphere_marker.pose.orientation.x = sphere_marker.pose.orientation.x / norm;
+      sphere_marker.pose.orientation.y = sphere_marker.pose.orientation.y / norm;
+      sphere_marker.pose.orientation.z = sphere_marker.pose.orientation.z / norm;
+    }
+
+    // Create a sphere point
+    // Add the point pair to the line message
+    sphere_marker.points.resize(1);
+    sphere_marker.colors.back() = color;
+
+    sphere_marker.id = index;
+
+    markers_array.markers.push_back(sphere_marker);
+  }
+
+  if (markers_array.markers.empty())
+  {
+    return false;
+  }
+
+  //RCLCPP_ERROR_STREAM(LOGGER, "get_subscription_count: " << marker_publisher->get_subscription_count()
+  //                                                       << " # of markers: " << markers_array.markers.size());
+  marker_publisher->publish(markers_array);
+  return true;
+}
+
 PostIterationFn
-get_iteration_path_publisher(moveit_visual_tools::MoveItVisualTools& visual_tools,
-                             const moveit::core::JointModelGroup* group,
-                             const rviz_visual_tools::Colors color = rviz_visual_tools::TRANSLUCENT_LIGHT)
+get_iteration_path_publisher(rclcpp::Publisher<visualization_msgs::msg::MarkerArray>::SharedPtr marker_publisher,
+                             planning_scene_monitor::PlanningSceneMonitorPtr planning_scene_monitor,
+                             const moveit::core::JointModelGroup* group)
 {
   assert(group != nullptr);
 
   std::shared_ptr<const moveit::core::RobotState> reference_state;
   {
-    planning_scene_monitor::LockedPlanningSceneRO scene(visual_tools.getPlanningSceneMonitor());
+    planning_scene_monitor::LockedPlanningSceneRO scene(planning_scene_monitor);
     reference_state = std::make_shared<moveit::core::RobotState>(scene->getCurrentState());
   }
 
-  PostIterationFn path_publisher = [=, &visual_tools](int /*iteration_number*/, double /*cost*/,
-                                                      const Eigen::MatrixXd& values) {
-    static thread_local robot_trajectory::RobotTrajectory trajectory(visual_tools.getRobotModel(), group);
+  PostIterationFn path_publisher = [=](int /*iteration_number*/, double /*cost*/, const Eigen::MatrixXd& values) {
+    static thread_local robot_trajectory::RobotTrajectory trajectory(planning_scene_monitor->getRobotModel(), group);
     fill_robot_trajectory(values, *reference_state, trajectory);
-    visual_tools.publishTrajectoryLine(trajectory, group, color);
-    visual_tools.trigger();
+
+    std::vector<const moveit::core::LinkModel*> tips;
+    if (!group->getEndEffectorTips(tips))
+    {
+      RCLCPP_ERROR_STREAM(LOGGER, "Unable to get end effector tips from jmg");
+    }
+
+    // For each end effector
+    for (const moveit::core::LinkModel* ee_parent_link : tips)
+    {
+      publishTrajectoryPoints(trajectory, ee_parent_link, marker_publisher, TRANSLUCENT_LIGHT);
+    }
   };
 
   return path_publisher;
 }
 
-DoneFn get_success_trajectory_publisher(moveit_visual_tools::MoveItVisualTools& visual_tools,
-                                        const moveit::core::JointModelGroup* group,
-                                        const rviz_visual_tools::Colors color = rviz_visual_tools::GREEN)
+DoneFn
+get_success_trajectory_publisher(rclcpp::Publisher<visualization_msgs::msg::MarkerArray>::SharedPtr marker_publisher,
+                                 planning_scene_monitor::PlanningSceneMonitorPtr planning_scene_monitor,
+                                 const moveit::core::JointModelGroup* group)
 {
   assert(group != nullptr);
 
   std::shared_ptr<const moveit::core::RobotState> reference_state;
   {
-    planning_scene_monitor::LockedPlanningSceneRO scene(visual_tools.getPlanningSceneMonitor());
+    planning_scene_monitor::LockedPlanningSceneRO scene(planning_scene_monitor);
     reference_state = std::make_shared<moveit::core::RobotState>(scene->getCurrentState());
   }
 
-  DoneFn path_publisher = [=, &visual_tools](bool success, int /*total_iterations*/, double /*final_cost*/,
-                                             const Eigen::MatrixXd& values) {
+  DoneFn path_publisher = [=](bool success, int /*total_iterations*/, double /*final_cost*/,
+                              const Eigen::MatrixXd& values) {
     static thread_local robot_trajectory::RobotTrajectory trajectory(reference_state->getRobotModel(), group);
     if (success)
     {
       fill_robot_trajectory(values, *reference_state, trajectory);
-      visual_tools.publishTrajectoryLine(trajectory, group, color);
-      visual_tools.publishTrajectoryPath(trajectory);
-      visual_tools.trigger();
+
+      std::vector<const moveit::core::LinkModel*> tips;
+      if (!group->getEndEffectorTips(tips))
+      {
+        RCLCPP_ERROR_STREAM(LOGGER, "Unable to get end effector tips from jmg");
+      }
+
+      // For each end effector
+      for (const moveit::core::LinkModel* ee_parent_link : tips)
+      {
+        publishTrajectoryPoints(trajectory, ee_parent_link, marker_publisher);
+      }
     }
   };
 

--- a/include/stomp_moveit/trajectory_visualization.hpp
+++ b/include/stomp_moveit/trajectory_visualization.hpp
@@ -103,7 +103,7 @@ get_success_trajectory_publisher(rclcpp::Publisher<visualization_msgs::msg::Mark
 
       const moveit::core::LinkModel* ee_parent_link = group->getOnlyOneEndEffectorTip();
 
-      if (ee_parent_link != nullptr)
+      if (ee_parent_link != nullptr && !trajectory.empty())
       {
         marker_publisher->publish(createTrajectoryMarkerArray(trajectory, ee_parent_link));
       }

--- a/include/stomp_moveit/trajectory_visualization.hpp
+++ b/include/stomp_moveit/trajectory_visualization.hpp
@@ -71,13 +71,10 @@ get_iteration_path_publisher(rclcpp::Publisher<visualization_msgs::msg::MarkerAr
 {
   assert(group != nullptr);
 
-  std::shared_ptr<const moveit::core::RobotState> reference_state;
-  {
-    planning_scene_monitor::LockedPlanningSceneRO scene(planning_scene_monitor);
-    reference_state = std::make_shared<moveit::core::RobotState>(scene->getCurrentState());
-  }
+  planning_scene_monitor::LockedPlanningSceneRO scene(planning_scene_monitor);
 
-  PostIterationFn path_publisher = [=](int /*iteration_number*/, double /*cost*/, const Eigen::MatrixXd& values) {
+  auto path_publisher = [this, group, reference_state = moveit::core::RobotState(scene->getCurrentState())](
+                            int /*iteration_number*/, double /*cost*/, const Eigen::MatrixXd& values) {
     static thread_local robot_trajectory::RobotTrajectory trajectory(planning_scene_monitor->getRobotModel(), group);
     fill_robot_trajectory(values, *reference_state, trajectory);
 
@@ -99,14 +96,11 @@ get_success_trajectory_publisher(rclcpp::Publisher<visualization_msgs::msg::Mark
 {
   assert(group != nullptr);
 
-  std::shared_ptr<const moveit::core::RobotState> reference_state;
-  {
-    planning_scene_monitor::LockedPlanningSceneRO scene(planning_scene_monitor);
-    reference_state = std::make_shared<moveit::core::RobotState>(scene->getCurrentState());
-  }
+  planning_scene_monitor::LockedPlanningSceneRO scene(planning_scene_monitor);
 
-  DoneFn path_publisher = [=](bool success, int /*total_iterations*/, double /*final_cost*/,
-                              const Eigen::MatrixXd& values) {
+  auto path_publisher = [this, group, reference_state = moveit::core::RobotState(scene->getCurrentState())](
+                            bool success, int /*total_iterations*/, double /*final_cost*/,
+                            const Eigen::MatrixXd& values) {
     static thread_local robot_trajectory::RobotTrajectory trajectory(reference_state->getRobotModel(), group);
     if (success)
     {

--- a/include/stomp_moveit/trajectory_visualization.hpp
+++ b/include/stomp_moveit/trajectory_visualization.hpp
@@ -17,7 +17,6 @@ namespace visualization
 
 namespace
 {
-const rclcpp::Logger LOGGER = rclcpp::get_logger("stomp_moveit");
 const auto GREEN = [](const double& a) {
   std_msgs::msg::ColorRGBA color;
   color.r = 0.1;
@@ -117,7 +116,6 @@ get_success_trajectory_publisher(rclcpp::Publisher<visualization_msgs::msg::Mark
 
           if (ee_parent_link != nullptr && !trajectory.empty())
           {
-            RCLCPP_INFO(LOGGER, "PUBLISH!!!!!!!!!");
             marker_publisher->publish(createTrajectoryMarkerArray(trajectory, ee_parent_link));
           }
         }

--- a/include/stomp_moveit/trajectory_visualization.hpp
+++ b/include/stomp_moveit/trajectory_visualization.hpp
@@ -33,7 +33,10 @@ bool publishTrajectoryPoints(const robot_trajectory::RobotTrajectory& robot_traj
                              rclcpp::Publisher<visualization_msgs::msg::MarkerArray>::SharedPtr marker_publisher,
                              const std_msgs::msg::ColorRGBA& color = GREEN(1.0))
 {
-  // Create Sphere Marker
+  if (robot_trajectory.empty())
+    return false;
+
+  // Initialize Sphere Marker
   visualization_msgs::msg::Marker sphere_marker;
   sphere_marker.header.frame_id = robot_trajectory.getRobotModel()->getModelFrame();
   sphere_marker.ns = "Path";
@@ -46,8 +49,8 @@ bool publishTrajectoryPoints(const robot_trajectory::RobotTrajectory& robot_traj
   sphere_marker.color = color;
   sphere_marker.frame_locked = false;
 
+  // Visualize end effector positions of Cartesian path as sphere markers
   visualization_msgs::msg::MarkerArray markers_array;
-  // Visualize end effector positions of cartesian path
   for (std::size_t index = 0; index < robot_trajectory.getWayPointCount(); index++)
   {
     const Eigen::Isometry3d& tip_pose = robot_trajectory.getWayPoint(index).getGlobalLinkTransform(ee_parent_link);
@@ -55,11 +58,6 @@ bool publishTrajectoryPoints(const robot_trajectory::RobotTrajectory& robot_traj
     sphere_marker.id = index;
 
     markers_array.markers.push_back(sphere_marker);
-  }
-
-  if (markers_array.markers.empty())
-  {
-    return false;
   }
 
   marker_publisher->publish(markers_array);

--- a/include/stomp_moveit/trajectory_visualization.hpp
+++ b/include/stomp_moveit/trajectory_visualization.hpp
@@ -35,7 +35,7 @@ bool publishTrajectoryPoints(const robot_trajectory::RobotTrajectory& robot_traj
 {
   // Create Sphere Marker
   visualization_msgs::msg::Marker sphere_marker;
-  sphere_marker.header.frame_id = "panda_link0";
+  sphere_marker.header.frame_id = robot_trajectory.getRobotModel()->getModelFrame();
   sphere_marker.ns = "Path";
   sphere_marker.type = visualization_msgs::msg::Marker::SPHERE;
   sphere_marker.action = visualization_msgs::msg::Marker::ADD;

--- a/include/stomp_moveit/trajectory_visualization.hpp
+++ b/include/stomp_moveit/trajectory_visualization.hpp
@@ -73,7 +73,7 @@ get_iteration_path_publisher(rclcpp::Publisher<visualization_msgs::msg::MarkerAr
 
   planning_scene_monitor::LockedPlanningSceneRO scene(planning_scene_monitor);
 
-  auto path_publisher = [this, group, reference_state = moveit::core::RobotState(scene->getCurrentState())](
+  auto path_publisher = [marker_publisher, group, reference_state = moveit::core::RobotState(scene->getCurrentState())](
                             int /*iteration_number*/, double /*cost*/, const Eigen::MatrixXd& values) {
     static thread_local robot_trajectory::RobotTrajectory trajectory(planning_scene_monitor->getRobotModel(), group);
     fill_robot_trajectory(values, *reference_state, trajectory);
@@ -98,7 +98,7 @@ get_success_trajectory_publisher(rclcpp::Publisher<visualization_msgs::msg::Mark
 
   planning_scene_monitor::LockedPlanningSceneRO scene(planning_scene_monitor);
 
-  auto path_publisher = [this, group, reference_state = moveit::core::RobotState(scene->getCurrentState())](
+  auto path_publisher = [marker_publisher, group, reference_state = moveit::core::RobotState(scene->getCurrentState())](
                             bool success, int /*total_iterations*/, double /*final_cost*/,
                             const Eigen::MatrixXd& values) {
     static thread_local robot_trajectory::RobotTrajectory trajectory(reference_state->getRobotModel(), group);

--- a/include/stomp_moveit/trajectory_visualization.hpp
+++ b/include/stomp_moveit/trajectory_visualization.hpp
@@ -84,7 +84,6 @@ get_iteration_path_publisher(rclcpp::Publisher<visualization_msgs::msg::MarkerAr
 
     if (ee_parent_link != nullptr && !trajectory.empty())
     {
-      RCLCPP_INFO(LOGGER, "PUBLISH!!!!!!!!!");
       marker_publisher->publish(createTrajectoryMarkerArray(trajectory, ee_parent_link, GREEN(0.5)));
     }
   };

--- a/include/stomp_moveit/trajectory_visualization.hpp
+++ b/include/stomp_moveit/trajectory_visualization.hpp
@@ -18,29 +18,20 @@ namespace visualization
 namespace
 {
 const rclcpp::Logger LOGGER = rclcpp::get_logger("stomp_moveit");
-const auto GREEN = []() {
+const auto GREEN = [](const double& a) {
   std_msgs::msg::ColorRGBA color;
   color.r = 0.1;
   color.g = 0.8;
   color.b = 0.1;
-  color.a = 1.0;
+  color.a = a;
   return color;
-}();
-
-const auto TRANSLUCENT_LIGHT = []() {
-  std_msgs::msg::ColorRGBA color;
-  color.r = 0.1;
-  color.g = 0.8;
-  color.b = 0.1;
-  color.a = 0.5;
-  return color;
-}();
+};
 }  // namespace
 
 bool publishTrajectoryPoints(const robot_trajectory::RobotTrajectory& robot_trajectory,
                              const moveit::core::LinkModel* ee_parent_link,
                              rclcpp::Publisher<visualization_msgs::msg::MarkerArray>::SharedPtr marker_publisher,
-                             const std_msgs::msg::ColorRGBA& color = GREEN)
+                             const std_msgs::msg::ColorRGBA& color = GREEN(1.0))
 {
   // Create Sphere Marker
   visualization_msgs::msg::Marker sphere_marker;
@@ -127,7 +118,7 @@ get_iteration_path_publisher(rclcpp::Publisher<visualization_msgs::msg::MarkerAr
     // For each end effector
     for (const moveit::core::LinkModel* ee_parent_link : tips)
     {
-      publishTrajectoryPoints(trajectory, ee_parent_link, marker_publisher, TRANSLUCENT_LIGHT);
+      publishTrajectoryPoints(trajectory, ee_parent_link, marker_publisher, GREEN(0.5));
     }
   };
 

--- a/package.xml
+++ b/package.xml
@@ -18,8 +18,10 @@
   <depend>stomp</depend>
   <depend>moveit_common</depend>
   <depend>moveit_core</depend>
-  <depend>moveit_ros_planning</depend>
   <depend>moveit_visual_tools</depend>
+  <depend>std_msgs</depend>
+  <depend>tf2_eigen</depend>
+  <depend>visualization_msgs</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/package.xml
+++ b/package.xml
@@ -18,7 +18,7 @@
   <depend>stomp</depend>
   <depend>moveit_common</depend>
   <depend>moveit_core</depend>
-  <depend>moveit_ros</depend>
+  <depend>moveit_ros_planning</depend>
   <depend>moveit_visual_tools</depend>
 
   <test_depend>ament_lint_auto</test_depend>

--- a/res/stomp_moveit.yaml
+++ b/res/stomp_moveit.yaml
@@ -57,3 +57,8 @@ stomp_moveit:
     description: "Assumed time change between consecutive points - used for computing control costs",
     default_value: 0.1,
   }
+  path_marker_topic: {
+    type: string,
+    description: "Name of the topic RVIZ subscribes to to visualize the EE path",
+    default_value: "",
+  }

--- a/src/stomp_moveit_example.cpp
+++ b/src/stomp_moveit_example.cpp
@@ -8,9 +8,10 @@
 #include <stomp_moveit/cost_functions.hpp>
 #include <stomp_moveit/stomp_moveit_task.hpp>
 
-// MoveItCpp
+// MoveIt
 #include <moveit/moveit_cpp/moveit_cpp.h>
 #include <moveit/moveit_cpp/planning_component.h>
+#include <moveit_visual_tools/moveit_visual_tools.h>
 
 using namespace std::chrono_literals;
 
@@ -95,10 +96,8 @@ int main(int argc, char** argv)
   auto cost_fn = costs::get_collision_cost_function(planning_scene, group, 1.0 /* collision penalty */);
   auto filter_fn = filters::chain(
       { filters::simple_smoothing_matrix(config.num_timesteps), filters::enforce_position_bounds(group) });
-  auto iteration_callback_fn = visualization::get_iteration_path_publisher(
-      markers_publisher, moveit_cpp->getPlanningSceneMonitorNonConst(), group);
-  auto done_callback_fn = visualization::get_success_trajectory_publisher(
-      markers_publisher, moveit_cpp->getPlanningSceneMonitorNonConst(), group);
+  auto iteration_callback_fn = visualization::get_iteration_path_publisher(markers_publisher, planning_scene, group);
+  auto done_callback_fn = visualization::get_success_trajectory_publisher(markers_publisher, planning_scene, group);
   stomp::TaskPtr task =
       std::make_shared<ComposableTask>(noise_generator_fn, cost_fn, filter_fn, iteration_callback_fn, done_callback_fn);
 

--- a/src/stomp_moveit_planner_plugin.cpp
+++ b/src/stomp_moveit_planner_plugin.cpp
@@ -24,13 +24,12 @@ public:
     node_ = node;
     parameter_namespace_ = parameter_namespace;
 
-    std::shared_ptr<stomp_moveit::ParamListener> param_listener =
-        std::make_shared<stomp_moveit::ParamListener>(node, parameter_namespace);
-    params_ = param_listener->get_params();
+    param_listener_ = std::make_shared<stomp_moveit::ParamListener>(node, parameter_namespace);
+    auto const params = param_listener_->get_params();
 
-    if (!params_.path_marker_topic.empty())
+    if (!params.path_marker_topic.empty())
     {
-      path_publisher_ = node->create_publisher<visualization_msgs::msg::MarkerArray>(params_.path_marker_topic,
+      path_publisher_ = node->create_publisher<visualization_msgs::msg::MarkerArray>(params.path_marker_topic,
                                                                                      rclcpp::SystemDefaultsQoS());
     }
 
@@ -57,7 +56,8 @@ public:
       return nullptr;
     }
 
-    PlanningContextPtr planning_context = std::make_shared<StompPlanningContext>("STOMP", req.group_name, params_);
+    PlanningContextPtr planning_context =
+        std::make_shared<StompPlanningContext>("STOMP", req.group_name, param_listener_->get_params());
     planning_context->setPlanningScene(planning_scene);
     planning_context->setMotionPlanRequest(req);
 
@@ -106,7 +106,7 @@ private:
   moveit::core::RobotModelConstPtr robot_model_;
   rclcpp::Node::SharedPtr node_;
   std::string parameter_namespace_;
-  stomp_moveit::Params params_;
+  std::shared_ptr<stomp_moveit::ParamListener> param_listener_;
   std::shared_ptr<rclcpp::Publisher<visualization_msgs::msg::MarkerArray>> path_publisher_;
 };
 

--- a/src/stomp_moveit_planning_context.cpp
+++ b/src/stomp_moveit_planning_context.cpp
@@ -4,7 +4,7 @@
 #include <stomp/stomp.h>
 
 #include <stomp_moveit/stomp_moveit_planning_context.hpp>
-// #include <stomp_moveit/trajectory_visualization.hpp>
+#include <stomp_moveit/trajectory_visualization.hpp>
 #include <stomp_moveit/filter_functions.hpp>
 #include <stomp_moveit/noise_generators.hpp>
 #include <stomp_moveit/cost_functions.hpp>
@@ -92,7 +92,7 @@ bool extractSeedTrajectory(const planning_interface::MotionPlanRequest& req,
   return !seed->empty();
 }
 
-stomp::TaskPtr createStompTask(const stomp::StompConfiguration& config, const StompPlanningContext& context)
+stomp::TaskPtr createStompTask(const stomp::StompConfiguration& config, StompPlanningContext& context)
 {
   const size_t num_timesteps = config.num_timesteps;
   const double collision_penalty = 1.0;
@@ -108,11 +108,11 @@ stomp::TaskPtr createStompTask(const stomp::StompConfiguration& config, const St
   auto cost_fn = costs::get_collision_cost_function(planning_scene, group, collision_penalty);
   auto filter_fn =
       filters::chain({ filters::simple_smoothing_matrix(num_timesteps), filters::enforce_position_bounds(group) });
-  // TODO: enable support for visualization
-  // auto iteration_callback_fn = visualization::get_iteration_path_publisher(visual_tools, group);
-  // auto done_callback_fn = visualization::get_success_trajectory_publisher(visual_tools, group);
-  PostIterationFn iteration_callback_fn = [](auto, auto, const auto&) {};
-  DoneFn done_callback_fn = [](auto, auto, auto, const auto&) {};
+
+  auto iteration_callback_fn =
+      visualization::get_iteration_path_publisher(context.getPathPublisher(), planning_scene, group);
+  auto done_callback_fn =
+      visualization::get_success_trajectory_publisher(context.getPathPublisher(), planning_scene, group);
   stomp::TaskPtr task =
       std::make_shared<ComposableTask>(noise_generator_fn, cost_fn, filter_fn, iteration_callback_fn, done_callback_fn);
   return task;
@@ -227,5 +227,16 @@ bool StompPlanningContext::terminate()
 
 void StompPlanningContext::clear()
 {
+}
+
+void StompPlanningContext::setPathPublisher(
+    std::shared_ptr<rclcpp::Publisher<visualization_msgs::msg::MarkerArray>> path_publisher)
+{
+  path_publisher_ = path_publisher;
+}
+
+std::shared_ptr<rclcpp::Publisher<visualization_msgs::msg::MarkerArray>> StompPlanningContext::getPathPublisher()
+{
+  return path_publisher_;
 }
 }  // namespace stomp_moveit


### PR DESCRIPTION
This PR implements a function to remove visual tools from the path visualization. The goal is to make it more generic so we'll have a visual tools agnostic visualization method for MoveIt planner plugins. When we move this into moveit, we can relocate it e.g. to https://github.com/ros-planning/moveit2/tree/main/moveit_ros/visualization

fixes #7 